### PR TITLE
SystemUI: Add a toggle for combined signal icons in status bar (1/2)

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -11172,6 +11172,11 @@ public final class Settings {
         public static final String GAME_DASHBOARD_ALWAYS_ON = "game_dashboard_always_on";
 
         /**
+         * @hide
+         */
+        public static final String SHOW_COMBINED_STATUS_BAR_SIGNAL_ICONS = "show_combined_status_bar_signal_icons";
+
+        /**
          * These entries are considered common between the personal and the managed profile,
          * since the managed profile doesn't get to change them.
          */

--- a/packages/SystemUI/src/com/android/systemui/statusbar/FeatureFlags.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/FeatureFlags.java
@@ -17,6 +17,9 @@
 package com.android.systemui.statusbar;
 
 import android.content.Context;
+import android.content.ContentResolver;
+import android.os.UserHandle;
+import android.provider.Settings;
 import android.util.FeatureFlagUtils;
 
 import com.android.systemui.R;
@@ -100,7 +103,10 @@ public class FeatureFlags {
 
     /** Whether or not to use the provider model behavior for the status bar icons */
     public boolean isCombinedStatusBarSignalIconsEnabled() {
-        return mFlagReader.isEnabled(R.bool.flag_combined_status_bar_signal_icons);
+        return Settings.Secure.getIntForUser(mContext.getContentResolver(),
+            Settings.Secure.SHOW_COMBINED_STATUS_BAR_SIGNAL_ICONS,
+            mFlagReader.isEnabled(R.bool.flag_combined_status_bar_signal_icons) ? 1 : 0,
+            UserHandle.USER_CURRENT) == 1;
     }
 
     /** System setting for provider model behavior */


### PR DESCRIPTION
* @jhonboy121: Use the feature flag as a default value, otherwise there is no point in having a "toggle" if the feature flag is not enabled

Change-Id: If869fe31e43f198c4ced8e872c5c060a524f6462

Signed-off-by: Sagarrokade006 <Sagarrokade006@gmail.com>